### PR TITLE
fix(grok): type conversion and decimal values

### DIFF
--- a/src/main/java/io/streamthoughts/kafka/connect/transform/data/internal/TypeConverter.java
+++ b/src/main/java/io/streamthoughts/kafka/connect/transform/data/internal/TypeConverter.java
@@ -216,6 +216,7 @@ public class TypeConverter implements Serializable {
         if (s.isEmpty()) {
             return false;
         }
+        boolean dotSeen = false;
         for (int i = 0; i < s.length(); i++) {
             if (i == 0 && s.charAt(i) == '-') {
                 if (s.length() == 1) {
@@ -223,6 +224,13 @@ public class TypeConverter implements Serializable {
                 } else {
                     continue;
                 }
+            }
+            if (s.charAt(i) == '.') {
+                if (dotSeen) {
+                    return false; // second dot → not a number
+                }
+                dotSeen = true;
+                continue;
             }
             if (Character.digit(s.charAt(i), 10) < 0) {
                 return false;

--- a/src/main/java/io/streamthoughts/kafka/connect/transform/pattern/GrokMatcher.java
+++ b/src/main/java/io/streamthoughts/kafka/connect/transform/pattern/GrokMatcher.java
@@ -62,9 +62,16 @@ public class GrokMatcher {
         Objects.requireNonNull(expression, "expression can't be null");
         this.patterns = patterns;
         this.expression = expression;
+        // Key by semantic (field name) when present, syntax (pattern name) otherwise,
+        // so that the lookup below — which uses the named capture group name from the
+        // compiled regex — correctly resolves the type hint for patterns of the form
+        // %{SYNTAX:semantic:TYPE}.
         this.patternsByName = patterns
             .stream()
-            .collect(Collectors.toMap(GrokPattern::syntax, p -> p,  (p1, p2) -> p1.semantic() != null ? p1 : p2));
+            .collect(Collectors.toMap(
+                p -> p.semantic() != null ? p.semantic() : p.syntax(),
+                p -> p,
+                (p1, p2) -> p1.semantic() != null ? p1 : p2));
         byte[] bytes = expression.getBytes(StandardCharsets.UTF_8);
         regex = new Regex(bytes, 0, bytes.length, Option.NONE, UTF8Encoding.INSTANCE);
 

--- a/src/test/java/io/streamthoughts/kafka/connect/transform/pattern/GrokMatcherTest.java
+++ b/src/test/java/io/streamthoughts/kafka/connect/transform/pattern/GrokMatcherTest.java
@@ -44,6 +44,33 @@ public class GrokMatcherTest {
     }
 
     @Test
+    public void should_convert_captured_values_to_type_specified_in_pattern() {
+        final GrokMatcher matcher = compiler.compile(
+            "%{NUMBER:aShort:SHORT} %{NUMBER:anInteger:INTEGER} %{NUMBER:aLong:LONG} " +
+            "%{NUMBER:aFloat:FLOAT} %{NUMBER:aDouble:DOUBLE} %{WORD:aBoolean:BOOLEAN} %{WORD:aString:STRING}"
+        );
+        final Map<String, Object> captured = matcher.captures(
+            "42 42 42 3.14 3.14 true hello".getBytes(StandardCharsets.UTF_8)
+        );
+
+        Assert.assertTrue(captured.get("aShort")   instanceof Short);
+        Assert.assertTrue(captured.get("anInteger") instanceof Integer);
+        Assert.assertTrue(captured.get("aLong")     instanceof Long);
+        Assert.assertTrue(captured.get("aFloat")    instanceof Float);
+        Assert.assertTrue(captured.get("aDouble")   instanceof Double);
+        Assert.assertTrue(captured.get("aBoolean")  instanceof Boolean);
+        Assert.assertTrue(captured.get("aString")   instanceof String);
+
+        Assert.assertEquals((short) 42, captured.get("aShort"));
+        Assert.assertEquals(42,         captured.get("anInteger"));
+        Assert.assertEquals(42L,        captured.get("aLong"));
+        Assert.assertEquals(3.14f,      (Float)  captured.get("aFloat"),  0.001f);
+        Assert.assertEquals(3.14,       (Double) captured.get("aDouble"), 0.001);
+        Assert.assertEquals(true,       captured.get("aBoolean"));
+        Assert.assertEquals("hello",    captured.get("aString"));
+    }
+
+    @Test
     public void should_parse_given_custom_grok_pattern() {
         final GrokMatcher matcher = compiler.compile("(?<EMAILADDRESS>(?<EMAILLOCALPART>[a-zA-Z][a-zA-Z0-9_.+-=:]+)@(?<HOSTNAME>\\b(?:[0-9A-Za-z][0-9A-Za-z-]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z-]{0,62}))*(\\.?|\\b)))");
         final Map<String, Object> captured = matcher.captures("test@kafka.org".getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## Fix type hints being ignored in `%{SYNTAX:semantic:TYPE}` patterns

### Problem

Two bugs prevented type hints from working correctly:

**1. `GrokMatcher`: type hint lookup always missed**

`patternsByName` was keyed by `syntax` (e.g. `NUMBER`), but the lookup during capture group resolution used the named group name from the compiled regex, which equals `semantic` (e.g. `measurement`). As a result, `getGrokPattern(field)` always returned `null` and every field fell back to `STRING`, regardless of the declared type hint.

**2. `TypeConverter.isNumber()`: decimal values rejected**

`isNumber()` only accepted digit characters, so values like `"3.14"` were not recognised as numbers. This caused `FLOAT` and `DOUBLE` conversions to throw a `DataException` whenever the matched value contained a decimal point.

### Fix

- **`GrokMatcher`**: key `patternsByName` by `semantic` when present, `syntax` otherwise, matching the key used at lookup time.
- **`TypeConverter`**: allow a single `.` in `isNumber()`, rejecting only strings with two or more dots.

### Test

Added `should_convert_captured_values_to_type_specified_in_pattern` in `GrokMatcherTest`, covering all seven supported type hints (`SHORT`, `INTEGER`, `LONG`, `FLOAT`, `DOUBLE`, `BOOLEAN`, `STRING`) with both type assertion and value assertion.